### PR TITLE
Update models.py

### DIFF
--- a/badgr_lite/models.py
+++ b/badgr_lite/models.py
@@ -27,7 +27,7 @@ class Badge:
     # There are enough public methods; pylint: disable=R0903
     # Attrs are dynamically assigned;  pylint: disable=E1101
 
-    REQUIRED_JSON = ['entityId', 'expires', 'entityType', 'extensions',
+    REQUIRED_JSON = ['entityId', 'expires',
                      'openBadgeId', 'createdBy', 'issuer', 'image',
                      'issuerOpenBadgeId', 'createdAt']
     REQUIRED_ATTRS = [pythonic(attr) for attr in REQUIRED_JSON]


### PR DESCRIPTION
Delete extensions and entityType from the Badge model's required Json. Now the json from Badgr doesn't include them.

Here we solve te following traceback:

packages\badgr_lite\models.py", line 68, in _check_missing_but_required
    raise exceptions.RequiredAttributesMissingError(
badgr_lite.exceptions.RequiredAttributesMissingError: extensions, entity_type